### PR TITLE
fix(build): GCC 14 -Wmaybe-uninitialized in esp_driver_i2c breaks fresh builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,14 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(PROJECT_VER "0.1.18-beta1")
 
 project(esp32_tsr)
+
+# GCC 14 (toolchain-xtensa-esp-elf 14.2.0) throws a false-positive
+# -Wmaybe-uninitialized in ESP-IDF's esp_driver_i2c/i2c_master.c
+# (ops_current in s_i2c_asynchronous_transaction), which IDF's global
+# -Werror then turns into a hard build failure. This project doesn't
+# touch that code path; downgrade just this one warning back to
+# non-fatal for that component rather than patching the framework.
+idf_component_get_property(_i2c_master_lib esp_driver_i2c COMPONENT_LIB)
+if(_i2c_master_lib)
+    target_compile_options(${_i2c_master_lib} PRIVATE -Wno-error=maybe-uninitialized)
+endif()

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ src_dir = main
 [env]
 framework = espidf
 monitor_speed = 115200
-upload_speed = 921600
+upload_speed = 115200
 build_flags =
   -Wall
   -Wno-unused-function
@@ -31,6 +31,7 @@ board = esp32s3box
 board_build.partitions = partitions.csv
 board_build.flash_mode = qio
 board_upload.flash_size = 4MB
+upload_flags = --no-stub
 ; Pre-build hooks:
 ;  - regen_embed.py forces a CMake reconfigure when main/index.html is
 ;    newer than main/index_html_data.c. Without this PIO caches the


### PR DESCRIPTION
## Summary

Building the current `esp32-s3` env fails out of the box with a fresh `espressif32@^6.4.0` pull, because of a GCC 14 false-positive warning inside a **vendored ESP-IDF driver**, not this project's own code.

### The failure

Toolchain in play: Espressif 32 **6.13.0**, `framework-espidf @ 3.50503.0 (5.5.3)`, `toolchain-xtensa-esp-elf @ 14.2.0+20251107`.

```
esp_driver_i2c/i2c_master.c: In function 's_i2c_asynchronous_transaction':
i2c_master.c:975:23: error: 'ops_current' may be used uninitialized [-Werror=maybe-uninitialized]
  975 |         i2c_queue_pre = (i2c_transaction_t) {
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
  976 |             .device_address = i2c_dev->device_address,
  977 |             .ops = ops_current,
  978 |             .cmd_count = ops_dim,
  979 |         };
i2c_master.c:950:26: note: 'ops_current' was declared here
  950 |         i2c_operation_t *ops_current;
cc1: some warnings being treated as errors
```

GCC 14.2.0 flags `ops_current` as possibly-uninitialized in ESP-IDF's own `esp_driver_i2c`. IDF's build system applies a project-wide `-Werror` (`tools/cmake/build.cmake`), turning this false-positive into a hard build failure for anyone on this toolchain version. This project doesn't use I2C — the driver is only pulled in transitively — so this will hit anyone building fresh once their local PlatformIO picks up `toolchain-xtensa-esp-elf 14.2.0+`.

(Note: this looks unrelated to the build failure in #9 — that one was reporter-diagnosed as a mirror/timeout issue on the pinned platform, not a compiler error, and was worked around by switching to the pioarduino platform fork entirely.)

### The fix

Rather than patching the vendored framework or weakening `-Werror` project-wide, the top-level `CMakeLists.txt` grabs the `esp_driver_i2c` component's library target after `project()` and appends `-Wno-error=maybe-uninitialized` to just that one target — no other warnings silenced, no other component touched. Confirmed the build completes and links successfully with this in place.

## Also included: upload reliability tweak + XIAO ESP32S3 follow-up (re: #9)

While getting this running I also had to change `upload_speed` (921600 → 115200) and add `upload_flags = --no-stub` in `platformio.ini` — `921600` with the stub uploader was unreliable for me. **Worth flagging: I tested this on a Seeed Studio XIAO ESP32S3 (native USB-Serial/JTAG interface), not the canonical N16R8 reference board**, so I'm not certain this is safe as a *global* default for everyone — you may want to make it conditional per-board rather than take it as-is. Happy to revert that half of the PR if it's not the right call for the reference hardware.

Hardware: **Seeed Studio XIAO ESP32S3** (purchased as part of a "Wio-SX1262 + XIAO ESP32S3" bundle — the LoRa carrier was **not** plugged in for this test). Confirmed via `esptool.py flash_id`:

```
Chip is ESP32-S3 (QFN56) (revision v0.2)
Features: WiFi, BLE, Embedded PSRAM 8MB (AP_3v3)
Manufacturer: c8   Device: 4017   Detected flash size: 8MB (quad)
```

So an **N8R8** config, same class as the existing Freenove ESP32-S3-WROOM N8R8 compatibility entry.

**This closes the XIAO loose end from #9** (where the compatibility table has it marked "☑️ partial, not fully verified yet" pending a follow-up that never landed): AP-join is confirmed working on a genuine XIAO ESP32S3, and the SSID observed was the current `ESP32-TSR-Setup`, not the old `myssid` default, so this isn't a stale-firmware artifact.

One rough edge worth documenting, though: **on the very first flash, the AP did not accept a join with the default password.** Only after a full `esptool erase_flash`, a `factory_reset --confirm`, and allowing extra time before retrying the join did it work. I don't have a serial log from that first failed attempt (only from after the erase), so I can't point to a specific root cause — flagging it as a known rough edge for first-time XIAO flashers rather than a diagnosed bug. Web UI login itself wasn't separately re-verified after that — only the AP join and the subsequent WireGuard/DERP data plane.

Once joined, a live serial-monitor session showed the WireGuard/DERP stack coming up cleanly — stable DERP control connection throughout, and both a direct P2P WireGuard session and a DERP-relayed session established correctly with tailnet peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)